### PR TITLE
docs: general contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ All our Arcus projects are structured the same way.
 - `src` folder with the actual code library
 - `build` folder with the YAML build pipelines and templates for Azure DevOps
 - `docs` folder with the current published and preview feature documentation
+- `.github` folder with the governance information like: current issue and pullrequest templates 
 
 ## Way of working
 Your assigned work should contain three things:


### PR DESCRIPTION
FIrst proposal on the general contribution guide of all the Arcus libraries.

This also contains the code guidelines, which are now located in the [general Arcus repo](https://github.com/arcus-azure/arcus/blob/master/DEVELOPER-GUIDE.md). We should probably favor this contribution file instead.

Closes https://github.com/arcus-azure/arcus/issues/160