### PR TITLE
chore: update to `main` default branch in contribution guide

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -15,6 +15,6 @@ Get started easily with our components:
 - [Arcus Templates](https://github.com/arcus-azure/arcus.templates)
 - [Arcus Web API](https://github.com/arcus-azure/arcus.webapi)
 
-We are open to contributions! For more infomration, see our [contribution guide](https://github.com/arcus-azure/.github/blob/master/CONTRIBUTING.md).
+We are open to contributions! For more infomration, see our [contribution guide](https://github.com/arcus-azure/.github/blob/main/CONTRIBUTING.md).
 
 Are you using Arcus? We are appy to have you as a [listed end-user](https://github.com/arcus-azure/arcus#customers)!


### PR DESCRIPTION
Use the renamed `main` default branch in the contribution guide.

Relates to https://github.com/arcus-azure/arcus/issues/169