### PR TITLE
docs: add testing link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -13,6 +13,7 @@ Get started easily with our components:
 - [Arcus Scripting](https://github.com/arcus-azure/arcus.scripting)
 - [Arcus Security](https://github.com/arcus-azure/arcus.security)
 - [Arcus Templates](https://github.com/arcus-azure/arcus.templates)
+- [Arcus Testing](https://github.com/arcus-azure/arcus.testing)
 - [Arcus Web API](https://github.com/arcus-azure/arcus.webapi)
 
 We are open to contributions! For more infomration, see our [contribution guide](https://github.com/arcus-azure/.github/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Add link to Testing repo as it is now more globally used.